### PR TITLE
Add HTML doctype and title to fix page rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
+<!DOCTYPE html>
 <html lang="de">
 <head>
   <meta charset="UTF-8" />
+  <title>sat.season</title>
 </head>
 <body>
   <nav>


### PR DESCRIPTION
## Summary
- ensure HTML renders in standards mode by declaring `<!DOCTYPE html>`
- provide page title metadata for better browser presentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ede977548333ab7380002ce242f1